### PR TITLE
feat: 쿠폰 갯수 Lock을 활용한 동시성 처리 - close #24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### INTELIJ ###
 .run
+
+### local env ###
+.env

--- a/core/app-core/src/main/java/com/webest/app/jpa/JpaAuditConfig.java
+++ b/core/app-core/src/main/java/com/webest/app/jpa/JpaAuditConfig.java
@@ -13,6 +13,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @Configuration
 @EnableJpaAuditing
 public class JpaAuditConfig implements AuditorAware<Long> {
+
     @Override
     public Optional<Long> getCurrentAuditor() {
 
@@ -29,8 +30,6 @@ public class JpaAuditConfig implements AuditorAware<Long> {
                 userId = Long.valueOf(userIdHeader);
             }
         }
-
-        System.out.println("유저 아이디 : " + userId);
 
         return Optional.ofNullable(userId);
     }

--- a/service/coupon/.gitignore
+++ b/service/coupon/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### local env ###
+.env

--- a/service/coupon/build.gradle
+++ b/service/coupon/build.gradle
@@ -18,6 +18,15 @@ dependencies {
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // redis-redisson 동시성처리
+    implementation 'org.redisson:redisson-spring-boot-starter:3.36.0'
+
+    // 테스트 container
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+
     // test DB
     testRuntimeOnly 'com.h2database:h2'
 }

--- a/service/coupon/src/main/java/com/webest/coupon/common/aop/RedissonLock.java
+++ b/service/coupon/src/main/java/com/webest/coupon/common/aop/RedissonLock.java
@@ -1,0 +1,21 @@
+package com.webest.coupon.common.aop;
+
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface RedissonLock {
+
+    String value(); // Lock의 고유 이름
+
+    long waitTime() default 5000L; // Lock획득 시도하는 최대 시간 (ms)
+
+    long leaseTime() default 2000L; // Lock을 획득한 후 점유하는 최대 시간 (ms)
+
+}

--- a/service/coupon/src/main/java/com/webest/coupon/common/aop/RedissonLockAspect.java
+++ b/service/coupon/src/main/java/com/webest/coupon/common/aop/RedissonLockAspect.java
@@ -1,0 +1,65 @@
+package com.webest.coupon.common.aop;
+
+import com.webest.coupon.common.exception.CouponErrorCode;
+import com.webest.coupon.common.exception.CouponException;
+import com.webest.coupon.common.parser.CustomSpringELParser;
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Order(Ordered.LOWEST_PRECEDENCE - 1)
+@RequiredArgsConstructor
+@Slf4j
+@Aspect
+@Component
+public class RedissonLockAspect {
+
+    private final RedissonClient redissonClient;
+
+    @Around("@annotation(com.webest.coupon.common.aop.RedissonLock)")
+    public void redissonLock(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        RedissonLock lockAnnotation = method.getAnnotation(RedissonLock.class);
+
+        String lockKey =
+            method.getName() + "-" + CustomSpringELParser.getDynamicValue(
+                signature.getParameterNames(),
+                joinPoint.getArgs(), lockAnnotation.value());
+
+        RLock lock = redissonClient.getLock(lockKey);
+
+        try {
+            boolean lockable = lock.tryLock(
+                lockAnnotation.waitTime(), lockAnnotation.leaseTime(), TimeUnit.MILLISECONDS);
+
+            if (!lockable) {
+                // 대기 시간 초과
+                log.info("Lock 획득 실패 : {}", lockKey);
+                throw new CouponException(CouponErrorCode.LOCK_WAITING_TIMEOUT);
+            }
+
+            joinPoint.proceed();
+
+        } catch (InterruptedException e) {
+            log.error("락 얻는 과정에서 에러 발생" + e);
+            throw e;
+        } finally {
+            // 락 해제
+            lock.unlock();
+        }
+
+    }
+
+}

--- a/service/coupon/src/main/java/com/webest/coupon/common/exception/CouponErrorCode.java
+++ b/service/coupon/src/main/java/com/webest/coupon/common/exception/CouponErrorCode.java
@@ -17,6 +17,7 @@ public enum CouponErrorCode {
 
     // 500
     DB_CONVERTING_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "DB 타입 변환 과정에서 오류 발생"),
+    LOCK_WAITING_TIMEOUT(HttpStatus.INTERNAL_SERVER_ERROR, "락의 대기시간 초과"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류"),
 
     ;

--- a/service/coupon/src/main/java/com/webest/coupon/common/parser/CustomSpringELParser.java
+++ b/service/coupon/src/main/java/com/webest/coupon/common/parser/CustomSpringELParser.java
@@ -1,0 +1,25 @@
+package com.webest.coupon.common.parser;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+/**
+ * Spring Expression Language Parser
+ */
+public class CustomSpringELParser {
+
+    private CustomSpringELParser() {
+    }
+
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/service/coupon/src/main/java/com/webest/coupon/common/parser/CustomSpringELParser.java
+++ b/service/coupon/src/main/java/com/webest/coupon/common/parser/CustomSpringELParser.java
@@ -10,9 +10,17 @@ import org.springframework.expression.spel.support.StandardEvaluationContext;
 public class CustomSpringELParser {
 
     private CustomSpringELParser() {
+        throw new UnsupportedOperationException("이 클래스는 인스턴스 생성을 지원하지 않습니다.");
     }
 
     public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+        if (parameterNames == null || args == null || key == null) {
+            throw new IllegalArgumentException("Input parameters cannot be null");
+        }
+        if (parameterNames.length != args.length) {
+            throw new IllegalArgumentException("parameterNames and args must have the same length");
+        }
+
         ExpressionParser parser = new SpelExpressionParser();
         StandardEvaluationContext context = new StandardEvaluationContext();
 

--- a/service/coupon/src/main/java/com/webest/coupon/common/property/RedisProperty.java
+++ b/service/coupon/src/main/java/com/webest/coupon/common/property/RedisProperty.java
@@ -1,0 +1,13 @@
+package com.webest.coupon.common.property;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("spring.data.redis")
+public record RedisProperty(
+    String host,
+    String username,
+    int port,
+    String password
+) {
+
+}

--- a/service/coupon/src/main/java/com/webest/coupon/infrastructure/CouponJpaRepository.java
+++ b/service/coupon/src/main/java/com/webest/coupon/infrastructure/CouponJpaRepository.java
@@ -19,4 +19,8 @@ public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
     @Query("select c from Coupon c left join fetch c.couponUserList cu"
         + " where cu.couponUserId = :couponUserId and cu.used = false")
     Optional<Coupon> findCouponByCouponUserId(Long couponUserId);
+
+
+    // 락은 분산락으로
+    Optional<Coupon> findCouponByCouponId(Long id);
 }

--- a/service/coupon/src/main/java/com/webest/coupon/infrastructure/config/PropertyConfig.java
+++ b/service/coupon/src/main/java/com/webest/coupon/infrastructure/config/PropertyConfig.java
@@ -1,0 +1,12 @@
+package com.webest.coupon.infrastructure.config;
+
+import static com.webest.web.common.CommonStaticVariable.BASE_PACKAGE;
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationPropertiesScan(BASE_PACKAGE + ".coupon")
+public class PropertyConfig {
+
+}

--- a/service/coupon/src/main/java/com/webest/coupon/infrastructure/config/RedisConfig.java
+++ b/service/coupon/src/main/java/com/webest/coupon/infrastructure/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.webest.coupon.infrastructure.config;
+
+import com.webest.coupon.common.property.RedisProperty;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+    private final RedisProperty redisProperty;
+
+    @Bean
+    public RedisConnectionFactory connectionFactory() {
+
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+
+        config.setHostName(redisProperty.host());
+        config.setUsername(redisProperty.username());
+        config.setPort(redisProperty.port());
+        config.setPassword(redisProperty.password());
+
+        return new LettuceConnectionFactory(config);
+
+
+    }
+
+}

--- a/service/coupon/src/main/java/com/webest/coupon/infrastructure/config/RedissonConfig.java
+++ b/service/coupon/src/main/java/com/webest/coupon/infrastructure/config/RedissonConfig.java
@@ -1,0 +1,27 @@
+package com.webest.coupon.infrastructure.config;
+
+import com.webest.coupon.common.property.RedisProperty;
+import lombok.RequiredArgsConstructor;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+public class RedissonConfig {
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    private final RedisProperty redisProperty;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+            .setAddress(REDISSON_HOST_PREFIX + redisProperty.host() + ":" + redisProperty.port())
+            .setUsername(redisProperty.username()).setPassword(redisProperty.password());
+        return Redisson.create(config);
+    }
+}

--- a/service/coupon/src/main/java/com/webest/coupon/presentation/dtos/response/CouponResponseDto.java
+++ b/service/coupon/src/main/java/com/webest/coupon/presentation/dtos/response/CouponResponseDto.java
@@ -14,7 +14,8 @@ public record CouponResponseDto(
     DiscountType discountType,
     Integer discountValue,
     LocalDateTime createTime,
-    Integer maxQuantity
+    Integer maxQuantity,
+    Integer issuedQuantity
 ) {
 
 }

--- a/service/coupon/src/main/resources/application.yml
+++ b/service/coupon/src/main/resources/application.yml
@@ -1,12 +1,19 @@
 spring:
+  config:
+    import: optional:file:./service/coupon/.env[.properties]
   application:
     name: coupon-service
-
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+  data:
+    redis:
+      host: ${DEV_REDIS_HOST}
+      port: 6379
+      username: ${DEV_REDIS_USERNAME}
+      password: ${DEV_REDIS_PASSWORD}
   jpa:
     hibernate:
       ddl-auto: create

--- a/service/coupon/src/test/java/com/webest/coupon/application/CouponUserServiceImplTest.java
+++ b/service/coupon/src/test/java/com/webest/coupon/application/CouponUserServiceImplTest.java
@@ -1,0 +1,93 @@
+package com.webest.coupon.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.webest.coupon.application.config.TestContainerConfig;
+import com.webest.coupon.domain.model.DateType;
+import com.webest.coupon.domain.model.DiscountType;
+import com.webest.coupon.presentation.dtos.request.CouponCreateRequestDto;
+import com.webest.coupon.presentation.dtos.response.CouponResponseDto;
+import java.time.LocalDate;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@ExtendWith(TestContainerConfig.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class CouponUserServiceImplTest {
+
+    @Autowired
+    private CouponServiceImpl couponService;
+
+    @Autowired
+    private CouponUserServiceImpl couponUserService;
+
+
+    @Nested
+    @DisplayName("쿠폰 동시성 테스트")
+    class couponConcurrent {
+
+
+        private Long couponId;
+
+        @BeforeEach
+        void initBefore() {
+            // User과 연관된 테이블은 현재 미존재
+            Long couponId = couponService.createCoupon(new CouponCreateRequestDto(
+                "치킨 할인 쿠폰",
+                1,
+                DateType.DAY,
+                LocalDate.parse("2024-10-01"),
+                LocalDate.parse("2024-10-10"),
+                DiscountType.FIXED,
+                3000,
+                200
+            ));
+            this.couponId = couponId;
+        }
+
+        @DisplayName("동시에 100개 요청")
+        @Test
+        public void 동시에_100개_요청() throws InterruptedException {
+            // given
+
+            CouponResponseDto couponById1 = couponService.findCouponById(couponId);
+
+            final int threadCount = 100;
+            ExecutorService executorService = Executors.newFixedThreadPool(30);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+            // when
+            final Long currentMemberId = 1L;
+            for (int i = 0; i < threadCount; i++) {
+                Long ad = i + 10L;
+                executorService.submit(() -> {
+                    try {
+                        couponUserService.issueCouponToUser(couponId, ad);
+                    } catch (Exception e) {
+//                        System.out.println("에러 발생 : " + ad + " : " + e);
+                    } finally {
+                        latch.countDown();
+                    }
+
+                });
+            }
+            latch.await();
+
+            CouponResponseDto couponById = couponService.findCouponById(couponId);
+//            List<CouponByUserResponseDto> couponListByUser = couponUserService.findCouponListByUser(
+//                currentMemberId, null);
+
+            // then
+            //assertThat(couponListByUser.size()).isEqualTo(100);
+            assertThat(couponById.issuedQuantity()).isEqualTo(threadCount);
+        }
+    }
+}

--- a/service/coupon/src/test/java/com/webest/coupon/application/config/TestContainerConfig.java
+++ b/service/coupon/src/test/java/com/webest/coupon/application/config/TestContainerConfig.java
@@ -1,0 +1,25 @@
+package com.webest.coupon.application.config;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@TestConfiguration
+public class TestContainerConfig implements BeforeAllCallback {
+
+    public static final String REDIS_IMAGE = "redis:7.4.0-alpine";
+    public static final Integer port = 6379;
+    public static GenericContainer<?> redis;
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        redis = new GenericContainer(
+            DockerImageName.parse(REDIS_IMAGE)).withExposedPorts(port).withReuse(true);
+
+        redis.start();
+        System.setProperty("spring.data.redis.host", redis.getHost());
+        System.setProperty("spring.data.redis.port", String.valueOf(redis.getMappedPort(port)));
+    }
+}

--- a/service/coupon/src/test/resources/application.yml
+++ b/service/coupon/src/test/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-port: 19097
+  port: 19097
 
 spring:
   cloud:
@@ -12,12 +12,14 @@ spring:
     url: jdbc:h2:mem:test
     username: sa
     password:
-#  data:
-#    redis:
-#      host: localhost
-#      port: 6379
-#      username: default
-#      password: systempass
+  jpa:
+    hibernate:
+      ddl-auto: create
+  #    properties:
+  #      hibernate:
+  #        show_sql: true # sql 로깅
+  #        format_sql: true # SQL 문 정렬하여 출력
+  #        highlight_sql: true # SQL 문 색 부여
 
 eureka:
   client:


### PR DESCRIPTION
## #️⃣연관된 이슈

>#24

## 📝작업 내용

>  Redission을 사용해서 분산락 적용
    분산락 테스트 코드 적용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `.gitignore` to ignore local environment files, including `.env`.
	- Introduced a new aspect for managing distributed locks during coupon issuance.
	- Added a parser for dynamic evaluation of Spring Expression Language (SpEL) expressions.

- **Tests**
	- Expanded test suite to include concurrency tests for coupon issuance.

- **Chores**
	- Updated `.gitignore` files in multiple directories to manage ignored files effectively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->